### PR TITLE
fix(desktop): prevent pasted content from reverting in CodeMirror editor

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.ts
@@ -55,10 +55,8 @@ export function useFileContent({
 					!isImage &&
 					!!filePath &&
 					!!worktreePath,
-				// Disable window-focus refetch: the file watcher (useWorkspaceFileEvents)
-				// already invalidates this query when the file changes on disk.
-				// Without this, switching apps to copy text then returning to paste
-				// triggers a refetch that races with the paste and can overwrite edits.
+				// useWorkspaceFileEvents is the authoritative invalidation source for on-disk changes;
+				// window-focus refetches are redundant and introduce a race with in-flight user edits.
 				refetchOnWindowFocus: false,
 			},
 		);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/components/CodeEditor/CodeEditor.tsx
@@ -177,9 +177,7 @@ export function CodeEditor({
 	const editableCompartment = useRef(new Compartment()).current;
 	const onChangeRef = useRef(onChange);
 	const onSaveRef = useRef(onSave);
-	// Tracks whether a dispatch was initiated by the value-sync effect (external prop change)
-	// vs a user edit. Used to prevent the value-sync effect's dispatch from propagating
-	// back through onChange and overwriting draftContentRef with old content.
+	// Guards against re-entrant onChange calls triggered by the value-sync effect's own dispatch.
 	const isExternalUpdateRef = useRef(false);
 	const { data: fontSettings } = electronTrpc.settings.getFontSettings.useQuery(
 		undefined,
@@ -200,10 +198,6 @@ export function CodeEditor({
 
 		const updateListener = EditorView.updateListener.of((update) => {
 			if (!update.docChanged) return;
-			// Skip onChange for dispatches initiated by the value-sync effect.
-			// If we didn't skip, the external value (e.g. stale rawFileData after
-			// a refetch) would propagate to handleEditorChange and overwrite
-			// draftContentRef.current, permanently losing the user's edits.
 			if (isExternalUpdateRef.current) return;
 			onChangeRef.current?.(update.state.doc.toString());
 		});
@@ -291,9 +285,7 @@ export function CodeEditor({
 		const currentValue = view.state.doc.toString();
 		if (currentValue === value) return;
 
-		// try/finally: if dispatch throws (e.g. view destroyed mid-effect), the flag
-		// must still reset — otherwise isExternalUpdateRef stays true forever and
-		// every subsequent user edit is silently dropped by the updateListener guard.
+		// Guarantee flag reset regardless of whether dispatch throws (e.g. view destroyed between null-check and dispatch).
 		isExternalUpdateRef.current = true;
 		try {
 			view.dispatch({


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/2459

## Summary
- Add `isExternalUpdateRef` guard in `CodeEditor` to prevent value-sync dispatches from re-entering `onChange` and overwriting user edits with stale file content.
- Add `refetchOnWindowFocus: false` to `readWorkingFile` query — `useWorkspaceFileEvents` is already the authoritative invalidation source; window-focus refetches were redundant and introduced a race with in-flight edits.

## Why / Context
Reported in #2459: pasting into the file editor briefly shows the pasted text then reverts to the original file content.

Root cause: `CodeMirror.view.dispatch()` is synchronous — the value-sync `useEffect([value])` dispatch immediately fires `updateListener → onChange → handleEditorChange`, overwriting `draftContentRef.current` with the stale `rawFileData` value before the paste had a chance to propagate.

## How It Works
`isExternalUpdateRef` is set to `true` immediately before the value-sync dispatch and reset in a `finally` block (guarantees reset even if dispatch throws, e.g. view destroyed mid-effect). The `updateListener` skips `onChange` while the flag is set, breaking the re-entrant loop.

## Manual QA
Tested the reported scenario in dev mode:
- [ ] Open a file → paste text → content persists (no revert)
- [ ] Switch away from the app and back (window focus) → unsaved edits not overwritten
- [ ] Type normally, save with Cmd+S → works as expected
- [ ] Open a file in read-only mode → no regressions

## Testing
No automated tests for CodeMirror integration — manually validated the paste regression in Electron dev mode against the exact scenario from #2459.